### PR TITLE
refactor(watcher): use chokidar@3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "vscode-i18n-fast",
-  "version": "0.0.2",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-i18n-fast",
-      "version": "0.0.2",
+      "version": "0.0.11",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/parser": "^7.26.8",
         "@babel/traverse": "^7.26.8",
         "@formatjs/icu-messageformat-parser": "^2.11.1",
         "@monyone/aho-corasick": "^1.0.4",
+        "chokidar": "^3.6.0",
         "crypto-js": "^4.2.0",
         "lodash": "^4.17.21",
         "minimatch": "^10.0.1",
@@ -724,6 +725,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -744,6 +758,18 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -756,7 +782,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -814,6 +839,42 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/color-convert": {
@@ -1258,7 +1319,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1307,6 +1367,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1490,11 +1564,22 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1511,7 +1596,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1523,7 +1607,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1698,6 +1781,15 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1822,7 +1914,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -1881,6 +1972,18 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2156,7 +2259,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "@babel/traverse": "^7.26.8",
     "@formatjs/icu-messageformat-parser": "^2.11.1",
     "@monyone/aho-corasick": "^1.0.4",
+    "chokidar": "^3.6.0",
     "crypto-js": "^4.2.0",
     "lodash": "^4.17.21",
     "minimatch": "^10.0.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,7 @@ export async function activate(context: ExtensionContext) {
 export async function deactivate() {
 	const workspaceKey = getWorkspaceKey();
 	if (workspaceKey) {
-		Hook.getInstance().dispose(workspaceKey);
-		I18n.getInstance().dispose(workspaceKey);
+		await Hook.getInstance().dispose(workspaceKey);
+		await I18n.getInstance().dispose(workspaceKey);
 	}
 }

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -35,16 +35,16 @@ class Hook {
         this.hookMap.delete(workspaceKey);
     }
 
-    private disposeWatcher(workspaceKey: string) {
+    private async disposeWatcher(workspaceKey: string) {
         const watcher = this.watcherMap.get(workspaceKey);
         if (!watcher) return;
-        watcher.dispose();
+        await watcher.dispose();
         this.watcherMap.delete(workspaceKey);
     }
 
-    dispose(workspaceKey: string) {
+    async dispose(workspaceKey: string) {
         this.disposeMap(workspaceKey);
-        this.disposeWatcher(workspaceKey);
+        await this.disposeWatcher(workspaceKey);
     }
 
     setHook(workspaceKey: string, path: string) {
@@ -75,7 +75,7 @@ class Hook {
     
             this.setHook(workspaceKey, file.fsPath);
 
-            this.watcherMap.set(workspaceKey, new Watcher(hookFilePattern).on(async (state, uri) => {
+            const watcher = await new Watcher().watch(hookFilePattern, async (state, uri) => {
                 switch (state) {
                     case WATCH_STATE.CHANGE:
                         this.setHook(workspaceKey, uri.fsPath);
@@ -86,7 +86,9 @@ class Hook {
                 }
 
                 await I18n.getInstance().reload();
-            }));
+            });
+
+            this.watcherMap.set(workspaceKey, watcher);
         } catch(error: any) {
             showMessage('warn', `<loadHook error> ${error?.stack}`);
         } finally {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -25,16 +25,16 @@ export default class I18n {
         this.i18nMap.delete(workspaceKey);
     }
 
-    private disposeWatcher(workspaceKey: string) {
+    private async disposeWatcher(workspaceKey: string) {
         const watcher = this.watcherMap.get(workspaceKey);
         if (!watcher) return;
-        watcher.dispose();
+        await watcher.dispose();
         this.watcherMap.delete(workspaceKey);
     }
 
-    dispose(workspaceKey: string) {
+    async dispose(workspaceKey: string) {
         this.disposeMap(workspaceKey);
-        this.disposeWatcher(workspaceKey);
+        await this.disposeWatcher(workspaceKey);
     }
 
     async init() {
@@ -53,7 +53,7 @@ export default class I18n {
         const i18nMap = await i18nFileUris.reduce<Promise<PathMap>>(async (map, i18nFileUri) => (await map).set(i18nFileUri.fsPath, await Hook.getInstance().collectI18n({ i18nFileUri })), Promise.resolve(new Map()));
         this.i18nMap.set(workspaceKey, i18nMap);
 
-        this.watcherMap.set(workspaceKey, new Watcher(i18nFilePattern).on(async (state, uri) => {
+        const watcher = await new Watcher().watch(i18nFilePattern, async (state, uri) => {
             const pathMap = this.i18nMap.get(workspaceKey) || new Map();
 
             switch (state) {
@@ -70,7 +70,9 @@ export default class I18n {
                     this.i18nMap.set(workspaceKey, pathMap);
                     break; 
             }
-        }));
+        });
+
+        this.watcherMap.set(workspaceKey, watcher);
     }
 
     get(): WorkspaceMap;

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -47,9 +47,9 @@ export default class Watcher implements Disposable {
             });
 
             this.watcher
-                .on('add', (relativePath) => callback?.(WATCH_STATE.CREATE, Uri.file(path.join(cwd, relativePath))))
-                .on('change', (relativePath) => callback?.(WATCH_STATE.CHANGE, Uri.file(path.join(cwd, relativePath))))
-                .on('unlink', (relativePath) => callback?.(WATCH_STATE.DELETE, Uri.file(path.join(cwd, relativePath))))
+                .on('add', (relativePath) => callback(WATCH_STATE.CREATE, Uri.file(path.join(cwd, relativePath))))
+                .on('change', (relativePath) => callback(WATCH_STATE.CHANGE, Uri.file(path.join(cwd, relativePath))))
+                .on('unlink', (relativePath) => callback(WATCH_STATE.DELETE, Uri.file(path.join(cwd, relativePath))))
                 .on('error', (error) => console.error(`Watcher(cwd: ${cwd}, pattern: ${rp.pattern}) error:`, error))
                 .on('ready', () => resolve(this));
         });

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -1,7 +1,8 @@
 import * as path from 'node:path';
-import { workspace, Uri } from 'vscode';
+import { workspace, Uri, RelativePattern } from 'vscode';
 // 这里为了支持 glob 用 chokidar@3.6.0 版本
 import { watch } from 'chokidar';
+import { isString } from 'lodash';
 
 import type { GlobPattern, Disposable } from "vscode";
 import type { FSWatcher } from 'chokidar';
@@ -26,10 +27,21 @@ export default class Watcher implements Disposable {
         this.cwd = cwd;
     }
 
-    public async watch(pattern: string | GlobPattern, callback: (state: WATCH_STATE, uri: Uri) => void): Promise<Watcher> {
+    private toRelativePattern(pattern: GlobPattern) {
+        if (isString(pattern)) {
+            return new RelativePattern(this.cwd, pattern);
+        }
+
+        return pattern;
+    }
+
+    public async watch(pattern: GlobPattern, callback: (state: WATCH_STATE, uri: Uri) => void): Promise<Watcher> {
+        const rp = this.toRelativePattern(pattern);
+        const cwd = rp.baseUri?.fsPath || this.cwd;
+
         return new Promise((resolve) => {
-            this.watcher = watch(pattern.toString(), {
-                cwd: this.cwd,
+            this.watcher = watch(rp.pattern, {
+                cwd,
                 persistent: true,
                 ignoreInitial: true,
             });
@@ -38,7 +50,7 @@ export default class Watcher implements Disposable {
                 .on('add', (relativePath) => callback?.(WATCH_STATE.CREATE, Uri.file(path.join(this.cwd, relativePath))))
                 .on('change', (relativePath) => callback?.(WATCH_STATE.CHANGE, Uri.file(path.join(this.cwd, relativePath))))
                 .on('unlink', (relativePath) => callback?.(WATCH_STATE.DELETE, Uri.file(path.join(this.cwd, relativePath))))
-                .on('error', (error) => console.error(`Watcher(cwd: ${this.cwd}, pattern: ${pattern.toString()}) error:`, error))
+                .on('error', (error) => console.error(`Watcher(cwd: ${cwd}, pattern: ${rp.pattern}) error:`, error))
                 .on('ready', () => resolve(this));
         });
     }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -47,9 +47,9 @@ export default class Watcher implements Disposable {
             });
 
             this.watcher
-                .on('add', (relativePath) => callback?.(WATCH_STATE.CREATE, Uri.file(path.join(this.cwd, relativePath))))
-                .on('change', (relativePath) => callback?.(WATCH_STATE.CHANGE, Uri.file(path.join(this.cwd, relativePath))))
-                .on('unlink', (relativePath) => callback?.(WATCH_STATE.DELETE, Uri.file(path.join(this.cwd, relativePath))))
+                .on('add', (relativePath) => callback?.(WATCH_STATE.CREATE, Uri.file(path.join(cwd, relativePath))))
+                .on('change', (relativePath) => callback?.(WATCH_STATE.CHANGE, Uri.file(path.join(cwd, relativePath))))
+                .on('unlink', (relativePath) => callback?.(WATCH_STATE.DELETE, Uri.file(path.join(cwd, relativePath))))
                 .on('error', (error) => console.error(`Watcher(cwd: ${cwd}, pattern: ${rp.pattern}) error:`, error))
                 .on('ready', () => resolve(this));
         });


### PR DESCRIPTION
Use `Chokidar` to monitor file changes and avoid the issue where events like `add`, `change`, and `unlink` are only triggered when file operations are performed within the VSCode.

> Using Chokidar@3.6.0 is to ensure support for glob patterns.