### PR TITLE
feat(publish): add Open VSX publishing support and update tasks in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,8 +146,9 @@
     "lint": "eslint src --ext ts",
     "publish": "npx zx scripts/publish.mjs",
     "publish:pre": "npx zx scripts/publish.mjs --tasks preCheck,updateVersion,updateChangelog",
-    "publish:all": "npx zx scripts/publish.mjs --tasks publishToVscode,gitPush,publishToGithub",
+    "publish:all": "npx zx scripts/publish.mjs --tasks publishToVscode,publishToOpenVsx,gitPush,publishToGithub",
     "publish:vscode": "npx zx scripts/publish.mjs --tasks publishToVscode",
+    "publish:openvsx": "npx zx scripts/publish.mjs --tasks publishToOpenVsx",
     "publish:github": "npx zx scripts/publish.mjs --tasks gitPush,publishToGithub",
     "package": "pnpm npx vsce package --no-dependencies",
     "package:alpha": "npx zx scripts/publish.mjs --tasks packageVsix --release prerelease --identifier alpha"

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -10,6 +10,7 @@ import 'dotenv/config';
 const REPO_OWNER = 'lvboda';
 const REPO_NAME = 'vscode-i18n-fast';
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const OPEN_VSX_TOKEN = process.env.OPEN_VSX_TOKEN;
 
 if (!GITHUB_TOKEN) {
   throw new Error('please set GITHUB_TOKEN environment variable');
@@ -100,6 +101,12 @@ async function publishToVscode() {
   console.log(chalk.green('✅ Published to VS Code Marketplace'));
 }
 
+async function publishToOpenVsx() {
+  console.log(chalk.blue('Publishing to Open VSX Registry...'));
+  await $`pnpm npx ovsx publish -p ${OPEN_VSX_TOKEN} --no-dependencies`;
+  console.log(chalk.green('✅ Published to Open VSX Registry'));
+}
+
 async function gitPush({ targetVersion }) {
   console.log(chalk.blue('Pushing code and tags...'));
 
@@ -176,6 +183,10 @@ const taskList = [
     task: publishToVscode,
   },
   {
+    key: 'publishToOpenVsx',
+    task: publishToOpenVsx,
+  },
+  {
     key: 'gitPush',
     task: gitPush,
   },
@@ -194,7 +205,7 @@ const taskList = [
 async function bootstrap() {
   try {
     const targetVersion = argv['version'] || argv['v'];
-    const tasksStr = argv['tasks'] || argv['t'] || 'preCheck,updateVersion,updateChangelog,publishToVscode,gitPush,publishToGithub';
+    const tasksStr = argv['tasks'] || argv['t'] || 'preCheck,updateVersion,updateChangelog,publishToVscode,publishToOpenVsx,gitPush,publishToGithub';
     const tasks = tasksStr.split(',');
 
     if (!tasks.length) {
@@ -211,7 +222,7 @@ async function bootstrap() {
       Object.assign(context, await taskList.find(t => t.key === task).task(context) || {});
     }
 
-    if (tasks.some(task => ['publishToVscode', 'publishToGithub'].includes(task))) {
+    if (tasks.some(task => ['publishToVscode', 'publishToOpenVsx', 'publishToGithub'].includes(task))) {
       console.log(chalk.green('🎉 Release completed!'));  
     } else {
       console.log(chalk.green('✅ All tasks finished!'));


### PR DESCRIPTION
## Summary by Sourcery

Add support for publishing the extension to the Open VSX Registry and integrate it into existing publish workflows

New Features:
- Add OPEN_VSX_TOKEN environment variable and publishToOpenVsx function in the publish script
- Include publishToOpenVsx in the default task sequence and completion checks
- Add a new npm script "publish:openvsx" and update "publish:all" to include the Open VSX publish task

Enhancements:
- Adjust publish script logic to handle Open VSX publication alongside existing targets