### PR TITLE
feat(package): update command labels to include 'I18n Fast' prefix in English and Chinese translations, closes #42

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -1,8 +1,8 @@
 {
     "package.description": "A hook-driven i18n plugin that supports diverse development scenarios.",
-    "package.commands.convert": "Convert",
-    "package.commands.paste": "Paste",
-    "package.commands.undo": "Undo",
+    "package.commands.convert": "I18n Fast: Convert",
+    "package.commands.paste": "I18n Fast: Paste",
+    "package.commands.undo": "I18n Fast: Undo",
     
     "package.configuration.title": "i18n-fast configuration",
     "package.configuration.hookFilePattern": "hook file pattern",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,8 +1,8 @@
 {
     "package.description": "一个 hook 驱动的 i18n 生成插件，满足多种国际化开发场景。",
-    "package.commands.convert": "转换",
-    "package.commands.paste": "粘贴",
-    "package.commands.undo": "撤销",
+    "package.commands.convert": "I18n Fast: 转换",
+    "package.commands.paste": "I18n Fast: 粘贴",
+    "package.commands.undo": "I18n Fast: 撤销",
     
     "package.configuration.title": "i18n-fast 配置",
     "package.configuration.hookFilePattern": "hook文件匹配规则",


### PR DESCRIPTION
closes #42

## Summary by Sourcery

New Features:
- Prefix all command labels with 'I18n Fast:' in both English and Chinese translations